### PR TITLE
commenting out scaling schedule to prevent service scaling up in ecs

### DIFF
--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -5,6 +5,6 @@ aws_profile = "staging-eu-west-2"
 use_set_environment_files = true
 
 # Scheduled scaling of tasks
-service_autoscale_enabled  = true
-service_scaledown_schedule = "55 19 * * ? *"
-service_scaleup_schedule   = "5 6 * * ? *"
+# service_autoscale_enabled  = true
+# service_scaledown_schedule = "55 19 * * ? *"
+# service_scaleup_schedule   = "5 6 * * ? *"


### PR DESCRIPTION
Team Thunderbirds want to deploy changes to psc-statement-data-api but cannot due to issues with psc-statement-delta-consumer causing blockers with their testing. The psc-satetement-delta-consumer has been scaled down and to stop it automatically scaling up each day we need to remove this section of tf code. 

Once Thunderbirds have deployed we can uncomment and merge back into the code. 