### PR TITLE
DSND-3109: Add delta at to delete delta test data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <ch-kafka.version>3.0.3</ch-kafka.version>
         <structured-logging.version>3.0.14</structured-logging.version>
         <kafka-models.version>3.0.8</kafka-models.version>
-        <private-api-sdk-java.version>4.0.191</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.210</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
 

--- a/src/itest/resources/json/input/psc_statement_delete.json
+++ b/src/itest/resources/json/input/psc_statement_delete.json
@@ -1,5 +1,6 @@
 {
   "company_number": "09950914",
   "psc_statement_id": "181ZGWm42-hTgP-LBAQTjWQnVzM",
-  "action": "DELETE"
+  "action": "DELETE",
+  "delta_at": "20230724093435661593"
 }

--- a/src/test/resources/psc-statement-delete-delta-example.json
+++ b/src/test/resources/psc-statement-delete-delta-example.json
@@ -1,5 +1,6 @@
 {
   "company_number": "09950914",
   "psc_statement_id": "181ZGWm42-hTgP-LBAQTjWQnVzM",
-  "action": "DELETE"
+  "action": "DELETE",
+  "delta_at": "20230724093435661593"
 }


### PR DESCRIPTION
This PR updates the tests to ensure the consumer can handle a delta_at field on an incoming delete delta.

[DSND-3109](https://companieshouse.atlassian.net/browse/DSND-3109)

[DSND-3109]: https://companieshouse.atlassian.net/browse/DSND-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ