### PR TITLE
DSND-3184: Increase resources to allow healthcheck to pass in live

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.253"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.292"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
@@ -28,7 +28,8 @@ module "secrets" {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.253"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.292"
+  read_only_root_filesystem = false
 
   # Environmental configuration
   environment             = var.environment
@@ -64,6 +65,8 @@ module "ecs-service" {
   use_capacity_provider              = var.use_capacity_provider
   use_fargate                        = var.use_fargate
   fargate_subnets                    = local.application_subnet_ids
+  service_autoscale_scale_in_cooldown  = var.service_autoscale_scale_in_cooldown
+  service_autoscale_scale_out_cooldown = var.service_autoscale_scale_out_cooldown
 
 
   # Service environment variable and secret configs

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -29,7 +29,6 @@ module "secrets" {
 
 module "ecs-service" {
   source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.292"
-  read_only_root_filesystem = false
 
   # Environmental configuration
   environment             = var.environment

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -4,10 +4,6 @@ aws_profile = "development-eu-west-2"
 # service configs
 use_set_environment_files = true
 
-required_cpus = 512
-required_memory = 1024
-service_autoscale_scale_out_cooldown = 600
-
 # Scheduled scaling of tasks
 service_autoscale_enabled  = true
 service_scaledown_schedule = "55 19 * * ? *"

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -4,3 +4,11 @@ aws_profile = "development-eu-west-2"
 # service configs
 use_set_environment_files = true
 
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600
+
+# Scheduled scaling of tasks
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -3,3 +3,7 @@ aws_profile = "live-eu-west-2"
 
 # service configs
 use_set_environment_files = true
+
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -4,7 +4,11 @@ aws_profile = "staging-eu-west-2"
 # service configs
 use_set_environment_files = true
 
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600
+
 # Scheduled scaling of tasks
-# service_autoscale_enabled  = true
-# service_scaledown_schedule = "55 19 * * ? *"
-# service_scaleup_schedule   = "5 6 * * ? *"
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -85,6 +85,16 @@ variable "service_scaleup_schedule" {
 
   default     = ""
 }
+variable "service_autoscale_scale_in_cooldown" {
+  type        = number
+  description = "Cooldown in seconds for ECS Service scale in (run fewer tasks)"
+  default     = 300
+}
+variable "service_autoscale_scale_out_cooldown" {
+  type        = number
+  description = "Cooldown in seconds for ECS Service scale out (add more tasks)"
+  default     = 300
+}
 
 # ----------------------------------------------------------------------
 # Cloudwatch alerts


### PR DESCRIPTION
This PR addresses an issue in live deployment of this app where the healthcheck endpoint fails during deployment (we think due to lack of resources). This change should fix this.

[DSND-3184](https://companieshouse.atlassian.net/browse/DSND-3184)

[DSND-3184]: https://companieshouse.atlassian.net/browse/DSND-3184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ