### PR TITLE
set jose4j to 0.9.6 to avoid vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <spring.boot.version>3.5.10</spring.boot.version>
+        <spring.boot.version>3.5.11</spring.boot.version>
         <spring-webmvc.version>6.2.16</spring-webmvc.version>
         <main.class>uk.gov.companieshouse.pscstatement.delta.PscStatementDeltaConsumerApplication</main.class>
         <map-struct.version>1.6.3</map-struct.version>
@@ -28,10 +28,10 @@
         <log4j-api.version>2.25.3</log4j-api.version>
 
         <!--CH Dependencies-->
-        <ch-kafka.version>3.0.6</ch-kafka.version>
+        <ch-kafka.version>3.0.7</ch-kafka.version>
         <structured-logging.version>3.0.50</structured-logging.version>
         <kafka-models.version>3.0.29</kafka-models.version>
-        <private-api-sdk-java.version>4.0.454</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.456</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.15</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>3.0.3</api-helper-java-library.version>
 
@@ -106,6 +106,13 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j-api.version}</version>
+        </dependency>
+        <!-- Pinning version to address CVE-2024-29371 in 0.9.4 pulled transitively by spring-kafka-test:jar:3.3.13-->
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <version>0.9.6</version>
+            <scope>compile</scope>
         </dependency>
         <!--		Transitive deps end here-->
         <dependency>


### PR DESCRIPTION
ASM-1507

Also up to spring-boot 3.5.11

`mvn verify` Successful

Delta:

<img width="557" height="518" alt="Screenshot 2026-02-20 at 1 29 26 pm" src="https://github.com/user-attachments/assets/9f7d1b07-acdf-4681-a76e-8e16c2b7f170" />


Data stored:

<img width="844" height="362" alt="Screenshot 2026-02-20 at 1 29 21 pm" src="https://github.com/user-attachments/assets/2152bba7-7189-45dd-b5ac-df31a3718050" />
